### PR TITLE
fix: remove chart param from list function.

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ YoutubeVideo.prototype.delete = function (id, callback) {
 }
 
 YoutubeVideo.prototype.list = function (params, callback) {
-  var options = merge({}, { part: 'status,snippet', chart: 'mostPopular' }, this.opts.video, params)
+  var options = merge({}, { part: 'status,snippet' }, this.opts.video, params)
   return this._command('list', options, callback)
 }
 


### PR DESCRIPTION
Couldn´t  get video by ID. Cause chart was defined. I removed this parameter.
https://developers.google.com/youtube/v3/docs/videos/list#filter-parameters
Greetings
